### PR TITLE
Added `release` keyword and `repository` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "grunt-release-component",
   "version": "0.0.3",
   "description": "A release helper for bower components",
+  "repository": "https://github.com/walmartlabs/grunt-release-component",
   "keywords": [
     "bower",
+    "release",
     "grunt"
   ],
   "dependencies": {


### PR DESCRIPTION
This repository is hard to find without the keyword 'release'. It is also harder to find the repository without the 'repository' key. I searched through npmjs.org
